### PR TITLE
New lines create new line IDs instead of moving them.

### DIFF
--- a/src/doc/TextChange.ts
+++ b/src/doc/TextChange.ts
@@ -88,8 +88,10 @@ export default class TextChange {
       if (options?.dontFixNewline) {
         this.compose(at, delta => delta.insert('\n', { ...format }));
       } else {
-        this.compose(at, delta => delta.insert('\n', lineFormat));
-        this.formatLine(at, { ...format });
+        // Steal the ID from the current line
+        this.compose(at, delta => delta.insert('\n', { id, ...lineFormat }));
+        // Clear the ID so that it acts as the new line
+        this.formatLine(at, { id: null, ...format });
       }
     } else {
       if (!format) format = this.getFormatAt(at);


### PR DESCRIPTION
This change modifies the handling of newline insertions in TextChange so that the leading text retains the current line ID and the trailing text is given a new line ID.

# Background
In the current implementation (without this change), inserting a new line actually moves the current line ID to the newly created line. In this example (using `^` as cursor position), editing :

```md
Hello, I am a fancy line
                        ^
```

...to... 

```md
Hello, I am a fancy line

^
```

...you would see a change in line ids from something like `['xhfkdf']` to `['hreoff', 'xhfkdf']`. The new line takes the old line's ID.

This is caused by how lines are re-parsed out of a new Delta document and where Delta stores line information (on the ending `\n` character). The system loops through each line of the delta and either uses the existing id or makes a new id (see `Line.fromDelta()` and `Delta.eachLine()`).

When you hit enter in the middle of a line, this inserts a new `\n` character, with no attributes. This means when lines are parsed out, the content _after_ the insertion retains the existing line id while the content _before_ the insertion has a new ID generated for it.

When a new line is inserted at the very end of a paragraph, your cursor is technically just before the ending newline of the paragraph. The existing paragraph is then interpreted as a new paragraph, while the new paragraph is interpreted as if the old paragraph had its content deleted.

When the rendering pass finally happens, this creates problems with custom elements. Because of the line ids, the existing content is seen as brand new, and all child elements are destroyed and recreated. For basic text, this is instant and invisible. For complex custom elements, they must be reinitialized. This can cause noticeable flicker. It is most easily diagnosed by logging on the custom element's `connectedCallback()` method; new lines will cause that method to fire.

# Implementation
This change works by applying the current ID (following the same concept as applying the current line format) to the new `\n` character. The subsequent `formatLine()` call is then automatically adjusted to target the existing newline. Reseting its id makes the mechanism in `Line.fromDelta()` interpret that line as a new line that needs a new ID.

With this change, everything preceding the new `\n` is left alone, and custom elements are able to remain stable. This greatly enhances the sensation of stability when editing text with such elements.