### PR TITLE
Apply changes to TextDocuments the smart way, instead of the easy way

### DIFF
--- a/examples/Basic.svelte
+++ b/examples/Basic.svelte
@@ -1,7 +1,9 @@
 <script>
 import { Editor, h } from 'typewriter-editor';
+import { options } from 'typewriter-editor/lib/rendering/vdom';
 import Root from 'typewriter-editor/lib/Root.svelte';
 
+options.renderKeys = true;
 window.h = h;
 const editor = window.editor = new Editor();
 </script>

--- a/src/Editor.ts
+++ b/src/Editor.ts
@@ -28,6 +28,7 @@ export interface EditorOptions {
   text?: string;
   html?: string;
   dev?: boolean;
+  throwOnError?: boolean;
 }
 
 export interface Shortcuts {
@@ -115,6 +116,7 @@ export default class Editor extends EventDispatcher {
   shortcuts: Shortcuts = {};
   modules: Modules = {};
   catchErrors: boolean;
+  throwOnError: boolean;
   _root!: HTMLElement;
   private _modules: ModuleInitializers;
   private _enabled: boolean;
@@ -133,6 +135,7 @@ export default class Editor extends EventDispatcher {
     } else {
       this.doc = new TextDocument();
     }
+    this.throwOnError = options.throwOnError || false;
     this._enabled = options.enabled === undefined ? true : options.enabled;
     this._modules = { ...defaultModules, ...options.modules };
     if (options.root) this.setRoot(options.root);
@@ -177,7 +180,7 @@ export default class Editor extends EventDispatcher {
       change = new TextChange(this.doc, change);
     }
     const old = this.doc;
-    const doc = old.apply(change);
+    const doc = old.apply(change, undefined, this.throwOnError);
     const changedLines = old.lines === doc.lines ? EMPTY_ARR : getChangedLines(old, doc);
     this.set(doc, source, change, changedLines);
     return this;

--- a/src/delta/Iterator.ts
+++ b/src/delta/Iterator.ts
@@ -12,7 +12,7 @@ export default class Iterator {
   }
 
   hasNext(): boolean {
-    return this.peekLength() < Infinity;
+    return !!this.peek();
   }
 
   next(length?: number): Op {

--- a/src/doc/Iterator.ts
+++ b/src/doc/Iterator.ts
@@ -1,7 +1,8 @@
 import Delta from '../delta/Delta';
-import Line from './Line';
+import Line, { LineIds } from './Line';
 
 const INFINITY = {
+  id: '',
   attributes: {},
   content: new Delta([ { retain: Infinity } ]),
   length: Infinity
@@ -11,11 +12,13 @@ export default class Iterator {
   lines: Line[];
   index: number;
   offset: number;
+  lineIds: LineIds;
 
-  constructor(lines: Line[]) {
+  constructor(lines: Line[], lineIds?: LineIds) {
     this.lines = lines;
     this.index = 0;
     this.offset = 0;
+    this.lineIds = lineIds ? new Map(lineIds) : Line.linesToLineIds(lines);
   }
 
   hasNext(): boolean {
@@ -40,11 +43,15 @@ export default class Iterator {
       if (offset === 0 && length >= nextLine.length) {
         return nextLine;
       } else {
-        return {
+        const id = offset === 0 ? nextLine.id : Line.createId(this.lineIds);
+        const partialLine = {
+          id,
           attributes: nextLine.attributes,
           content: nextLine.content.slice(offset, length),
           length: length - offset
         };
+        if (offset !== 0) this.lineIds.set(id, partialLine);
+        return partialLine;
       }
     } else {
       return INFINITY;

--- a/src/doc/Iterator.ts
+++ b/src/doc/Iterator.ts
@@ -22,7 +22,7 @@ export default class Iterator {
   }
 
   hasNext(): boolean {
-    return this.peekLength() < Infinity;
+    return !!this.peek();
   }
 
   next(length?: number): Line {

--- a/src/doc/Line.ts
+++ b/src/doc/Line.ts
@@ -34,6 +34,7 @@ namespace Line {
   }
 
   export function getId(line: Line): string {
+    console.warn('getId() is deprecated');
     return line.id;
   }
 

--- a/src/doc/Line.ts
+++ b/src/doc/Line.ts
@@ -11,6 +11,7 @@ export type LineIds = Map<string, Line>;
 export type LineInfo = {ranges: LineRanges, ids: LineIds};
 
 interface Line {
+  id: string;
   attributes: AttributeMap;
   content: Delta;
   length: number;
@@ -18,8 +19,14 @@ interface Line {
 
 
 namespace Line {
-  export function iterator(lines: Line[]) {
-    return new Iterator(lines);
+  export function iterator(lines: Line[], lineIds?: LineIds) {
+    return new Iterator(lines, lineIds);
+  }
+
+  export function linesToLineIds(lines: Line[]) {
+    const lineIds = new Map();
+    lines.forEach(line => lineIds.set(line.id || Line.createId(lineIds), line));
+    return lineIds;
   }
 
   export function length(line: Line): number {
@@ -27,7 +34,7 @@ namespace Line {
   }
 
   export function getId(line: Line): string {
-    return line.attributes.id;
+    return line.id;
   }
 
   export function equal(value: Line, other: Line) {
@@ -41,31 +48,26 @@ namespace Line {
 
     delta.eachLine((content, attr) => {
       const line = Line.create(content, Object.keys(attr).length ? attr : undefined, ids);
-      ids.set(Line.getId(line), line);
+      ids.set(line.id, line);
       lines.push(line);
     });
 
     return lines;
   }
 
-  export function toDelta(lines: Line[], keepIds?: boolean): Delta {
+  export function toDelta(lines: Line[]): Delta {
     let delta = new Delta();
     lines.forEach(line => {
       delta = delta.concat(line.content);
-      let attributes = line.attributes;
-      if (!keepIds) {
-        const { id, ...rest } = attributes;
-        attributes = rest;
-      }
-      delta.insert('\n', attributes);
+      delta.insert('\n', line.attributes);
     });
     return delta;
   }
 
-  export function create(content: Delta = new Delta(), attributes: AttributeMap = {}, existing?: LineIds): Line {
+  export function create(content: Delta = new Delta(), attributes: AttributeMap = {}, id?: string | LineIds): Line {
     const length = content.length() + 1;
-    if (!attributes.id) attributes = { ...attributes, id: createId(existing) };
-    return { attributes, content: content, length };
+    if (typeof id !== 'string') id = createId(id);
+    return { id, attributes, content: content, length };
   }
 
   export function getLineRanges(lines: Line[]) {

--- a/src/doc/Line.ts
+++ b/src/doc/Line.ts
@@ -70,6 +70,12 @@ namespace Line {
     return { id, attributes, content: content, length };
   }
 
+  export function createFrom(line?: Line, lineIds?: LineIds): Line {
+    const id = line ? line.id : createId(lineIds);
+    const attributes = line ? line.attributes : {};
+    return { id, attributes, content: new Delta(), length: 1 };
+  }
+
   export function getLineRanges(lines: Line[]) {
     const ranges = new Map<Line, EditorRange>() as LineRanges;
     let pos = 0;

--- a/src/doc/LineOp.ts
+++ b/src/doc/LineOp.ts
@@ -1,12 +1,12 @@
 import LineIterator from './Iterator';
 import OpIterator from '../delta/Iterator';
-import Line from './Line';
+import Line, { LineIds } from './Line';
 import Op from '../delta/Op';
 
 
 namespace LineOp {
-  export function iterator(lines: Line[]) {
-    return new LineOpIterator(lines);
+  export function iterator(lines: Line[], lineIds?: LineIds) {
+    return new LineOpIterator(lines, lineIds);
   }
 
   export const length = Op.length;
@@ -18,8 +18,8 @@ class LineOpIterator {
   lineIterator: LineIterator;
   opsIterator: OpIterator;
 
-  constructor(lines: Line[]) {
-    this.lineIterator = new LineIterator(lines);
+  constructor(lines: Line[], lineIds?: LineIds) {
+    this.lineIterator = new LineIterator(lines, lineIds);
     const line = this.lineIterator.peek();
     this.opsIterator = new OpIterator(line?.content.ops || []);
   }

--- a/src/doc/TextDocument.ts
+++ b/src/doc/TextDocument.ts
@@ -140,7 +140,7 @@ export default class TextDocument {
     return new Delta(ops);
   }
 
-  apply(change: Delta | TextChange, selection?: EditorRange | null): TextDocument {
+  apply(change: Delta | TextChange, selection?: EditorRange | null, throwOnError?: boolean): TextDocument {
     let delta: Delta;
     if (change instanceof TextChange) {
       delta = change.delta;
@@ -208,7 +208,7 @@ export default class TextDocument {
         const thisOp = thisIter.next(length);
         const otherOp = otherIter.next(length);
         if (typeof thisOp.retain === 'number') {
-          // throw new Error('apply() called with change that extends beyond document');
+          if (throwOnError) throw new Error('apply() called with change that extends beyond document');
           continue;
         }
 

--- a/src/doc/TextDocument.ts
+++ b/src/doc/TextDocument.ts
@@ -196,7 +196,8 @@ export default class TextDocument {
         if (index < 0) {
           line.content.push(otherIter.next());
         } else {
-          if (index) line.content.push(otherIter.next(index));
+          const nextIndex = index - otherIter.offset;
+          if (nextIndex) line.content.push(otherIter.next(nextIndex));
           const newlineOp = otherIter.next(1);
           const nextAttributes = line.attributes;
           line.attributes = newlineOp.attributes || {};

--- a/src/doc/TextDocument.ts
+++ b/src/doc/TextDocument.ts
@@ -154,7 +154,7 @@ export default class TextDocument {
       return this;
     }
 
-    // Optimization for selection change
+    // Optimization for selection-only change
     if (!delta.ops.length && selection) {
       return new TextDocument(this, selection);
     }
@@ -167,61 +167,87 @@ export default class TextDocument {
       }
     }
 
-    const lineIter = Line.iterator(this.lines, this.byId);
-    const changeIter = Op.iterator(delta.ops);
+    const thisIter = LineOp.iterator(this.lines, this.byId);
+    const otherIter = Op.iterator(delta.ops);
     let lines: Line[] = [];
-    const firstChange = changeIter.peek();
+    const firstChange = otherIter.peek();
     if (firstChange && firstChange.retain && !firstChange.attributes) {
       let firstLeft = firstChange.retain;
-      while (lineIter.peekLength() <= firstLeft) {
-        firstLeft -= lineIter.peekLength();
-        lines.push(lineIter.next());
+      while (thisIter.peekLineLength() <= firstLeft) {
+        firstLeft -= thisIter.peekLineLength();
+        lines.push(thisIter.nextLine());
       }
       if (firstChange.retain - firstLeft > 0) {
-        changeIter.next(firstChange.retain - firstLeft);
+        otherIter.next(firstChange.retain - firstLeft);
       }
     }
 
-    if (changeIter.index !== 0 || changeIter.offset !== 0) {
-      delta = new Delta(changeIter.rest());
+    let line = Line.createFrom(thisIter.peekLine());
+
+    function addLine(line: Line) {
+      line.length = line.content.length() + 1;
+      lines.push(line);
     }
 
-    const affectedLines: Line[] = [];
-    let lengthAffected = delta.reduce((length, op) => length + (op.insert ? 0 : Op.length(op)), 0);
-    do {
-      lengthAffected -= lineIter.peekLength();
-      affectedLines.push(lineIter.next());
-    } while (lineIter.hasNext() && lengthAffected >= 0)
+    while (thisIter.hasNext() || otherIter.hasNext()) {
+      if (otherIter.peekType() === 'insert') {
+        const otherOp = otherIter.peek();
+        const index = typeof otherOp.insert === 'string' ? otherOp.insert.indexOf('\n', otherIter.offset) : -1;
+        if (index < 0) {
+          line.content.push(otherIter.next());
+        } else {
+          if (index) line.content.push(otherIter.next(index));
+          const newlineOp = otherIter.next(1);
+          const nextAttributes = line.attributes;
+          line.attributes = newlineOp.attributes || {};
+          addLine(line);
+          line = Line.create(undefined, nextAttributes, this.byId);
+        }
+      } else {
+        const length = Math.min(thisIter.peekLength(), otherIter.peekLength());
+        const thisOp = thisIter.next(length);
+        const otherOp = otherIter.next(length);
+        if (typeof thisOp.retain === 'number') {
+          // throw new Error('apply() called with change that extends beyond document');
+          continue;
+        }
 
-    // if (lengthAffected > 0) {
-    //   if (lineIter.hasNext()) {
-    //     lengthAffected -= lineIter.peekLength();
-    //     affectedLines.push(lineIter.next());
-    //     if (lengthAffected > 0) {
-    //       console.log('Extending last line!!!!!!!');
-    //       const lastIndex = affectedLines.length - 1;
-    //       const lastLine = affectedLines[lastIndex];
-    //       affectedLines[lastIndex] = {
-    //         ...lastLine,
-    //         content: lastLine.content.slice().insert('#'.repeat(lengthAffected), lastLine.content.ops[lastLine.content.ops.length - 1].attributes),
-    //       };
-    //     }
-    //   } else {
-    //     console.log('Adding new line');
-    //     // const lastLine = { ...this.lines[this.lines.length - 1] };
-    //     affectedLines.push(Line.create(new Delta().insert('#'.repeat(lengthAffected)), undefined, this.byId));
-    //     // lastLine.content = lastLine.content.slice().insert('#'.repeat(lengthAffected));
-    //     // affectedLines.push(lastLine);
-    //   }
-    // }
+        if (typeof otherOp.retain === 'number') {
+          const isLine = thisOp.insert === '\n';
+          let newOp: Op = thisOp;
+          // Preserve null when composing with a retain, otherwise remove it for inserts
+          const attributes = otherOp.attributes && AttributeMap.compose(thisOp.attributes, otherOp.attributes);
+          if (otherOp.attributes && !isEqual(attributes, thisOp.attributes)) {
+            if (isLine) {
+              line.attributes = attributes || {};
+            } else {
+              newOp = { insert: thisOp.insert };
+              if (attributes) newOp.attributes = attributes;
+            }
+          }
+          if (isLine) {
+            addLine(line);
+            line = Line.createFrom(thisIter.peekLine());
+          } else {
+            line.content.push(newOp);
+          }
 
-    const updated = applyDeltaToLines(delta, affectedLines, this.byId);
-    if (updated.length === affectedLines.length && updated.every((b, i) => b === affectedLines[i])) {
-      return this.selection === selection ? this : new TextDocument(this, selection);
+          // Optimization if at the end of other
+          if (otherOp.retain === Infinity || !otherIter.hasNext()) {
+            if (thisIter.opIterator.index !== 0 || thisIter.opIterator.offset !== 0) {
+              const ops = thisIter.restCurrentLine();
+              for (let i = 0; i < ops.length; i++) {
+                line.content.push(ops[i]);
+              }
+              addLine(line);
+              thisIter.nextLine();
+            }
+            lines.push(...thisIter.restLines());
+            break;
+          }
+        } // else ... otherOp should be a delete so we won't add the next thisOp insert
+      }
     }
-
-    lines = lines.concat(updated);
-    lines = lines.concat(lineIter.rest());
 
     return new TextDocument(lines, selection);
   }
@@ -274,18 +300,6 @@ function getAttributes(Type: any, data: any, from: number, to: number, filter?: 
     }
   }
   return attributes || EMPTY_OBJ;
-}
-
-function applyDeltaToLines(delta: Delta, lines: Line[], byId: LineIds) {
-  if (!lines.length) return lines;
-  const ids = lines.map(line => line.id);
-  const applied = Line.toDelta(lines).compose(delta, true);
-  while (applied.ops.length && !applied.ops[applied.ops.length - 1].insert) applied.ops.pop();
-  return Line.fromDelta(applied, byId).map((line, i) => {
-    if (ids[i]) line.id = ids[i];
-    const old = byId.get(line.id);
-    return old && Line.equal(old, line) ? old : line;
-  });
 }
 
 // Intersect 2 attibute maps, keeping only those that are equal in both

--- a/src/modules/decorations.ts
+++ b/src/modules/decorations.ts
@@ -165,8 +165,8 @@ export function decorations(editor: Editor): DecorationsModule {
           // Ensure the id of each line is the same
           doc.lines.forEach((line, i) => {
             const origLine = original.lines[i];
-            if (line !== origLine && Line.getId(line) !== Line.getId(origLine)) {
-              line.attributes.id = origLine.attributes.id;
+            if (line !== origLine && line.id !== origLine.id) {
+              line.id = origLine.id;
             }
           })
         }

--- a/src/modules/history.ts
+++ b/src/modules/history.ts
@@ -114,7 +114,7 @@ export function initHistory(initOptions: Partial<Options> = {}) {
       const action = getAction(change);
       stack.redo.length = 0;
 
-      const undo = new TextChange(null, change.delta.invert(oldDoc.toDelta(true)), oldDoc.selection);
+      const undo = new TextChange(null, change.delta.invert(oldDoc.toDelta()), oldDoc.selection);
 
       // Break combining if actions are different (e.g. a delete then an insert should break it)
       if (!action || lastAction !== action) cutoffHistory();

--- a/src/modules/tables.ts
+++ b/src/modules/tables.ts
@@ -14,12 +14,12 @@ const TableType: LineType = {
     const table = h('table', null, [ row ]);
 
     for (let i = 0; i < lines.length; i++) {
-      const [ attributes, children ] = lines[i];
+      const [ attributes, children, id ] = lines[i];
       if (row.key !== attributes.table) {
         row = h(attributes.table.startsWith('th-') ? 'th' : 'tr', { key: attributes.table });
         table.children.push(row);
       }
-      row.children.push(h('td', { key: attributes.id }));
+      row.children.push(h('td', { key: id }));
     }
 
     return table;

--- a/src/rendering/rendering.ts
+++ b/src/rendering/rendering.ts
@@ -139,15 +139,15 @@ export function renderSingleLine(editor: Editor, line: Line, forHTML?: boolean) 
   if (!type.render) throw new Error('No render method defined for line');
   const node = type.render(line.attributes as AttributeMap, renderInline(editor, line.content), editor, forHTML);
   applyDecorations(node, line.attributes);
-  node.key = line.attributes.id;
+  node.key = line.id;
   return node;
 }
 
 export function renderMultiLine(editor: Editor, lines: Line[], forHTML?: boolean) {
   const type = getLineType(editor, lines[0]);
   if (!type.renderMultiple) throw new Error('No render method defined for line');
-  const node = type.renderMultiple(lines.map(line => [ line.attributes, renderInline(editor, line.content) ]), editor, forHTML);
-  node.key = lines[0].attributes.id;
+  const node = type.renderMultiple(lines.map(line => [ line.attributes, renderInline(editor, line.content), line.id ]), editor, forHTML);
+  node.key = lines[0].id;
   return node;
 }
 
@@ -175,12 +175,12 @@ export function combineLines(editor: Editor, lines: Line[]): CombinedData {
           linesMultiples.set(collect[0], collect);
         }
         combined.push(collect);
-        byKey[Line.getId(collect[0])] = collect;
+        byKey[collect[0].id] = collect;
         collect = [];
       }
     } else if (type.render) {
       combined.push(line);
-      byKey[Line.getId(line)] = line;
+      byKey[line.id] = line;
     }
   });
 

--- a/src/rendering/vdom.ts
+++ b/src/rendering/vdom.ts
@@ -12,17 +12,28 @@ export interface VNode {
   key: any
 }
 
+// Expose to allow debugging of keys on line elements
+export const options = {
+  renderKeys: false,
+};
+
 type Node = Element | Text;
 
 
 const EMPTY_ARR = []
 const SVG_NS = 'http://www.w3.org/2000/svg'
+const KEY_ATTR = 'data-key';
 const domProps = new Set([ 'value', 'selected', 'checked', 'contentEditable' ])
 
 const getKey = (vdom: VChild | Node) => (vdom == null ? vdom : (vdom as any).key)
 const setKey = (dom: any, key?: string) => {
-  if (key && key !== dom.key) dom.key = key
-  if (!key && dom.key) delete dom.key
+  if (key && key !== dom.key) {
+    dom.key = key
+    options.renderKeys && dom.setAttribute(KEY_ATTR, key);
+  } if (!key && dom.key) {
+    delete dom.key
+    options.renderKeys && dom.removeAttribute(KEY_ATTR);
+  }
 }
 
 const listener = (event: Event) => {
@@ -70,7 +81,7 @@ const getDomProps = (dom: Element, isSvg?: boolean): Props => {
     const { name, value } = dom.attributes[i]
     if (name in dom && name !== 'list' && !isSvg) {
       props[name] = dom[name]
-    } else {
+    } else if (!options.renderKeys || name !== KEY_ATTR) {
       props[name] = value === '' ? true : value
     }
   }

--- a/src/typesetting/lines.ts
+++ b/src/typesetting/lines.ts
@@ -93,15 +93,15 @@ export const list = line({
     const levels: VNode[] = [];
     // e.g. levels = [ul, ul]
 
-    lists.forEach(([ attributes, children ]) => {
+    lists.forEach(([ attributes, children, id ]) => {
       const type = attributes.list === 'ordered' ? 'ol' : 'ul';
       const index = attributes.indent as number || 0;
-      let props: Props = { key: attributes.id };
+      let props: Props = { key: id };
       if (attributes.list === 'check') {
         function toggle(event: any) {
           if (!editor.enabled) return;
           event.preventDefault();
-          editor.commands.toggleCheck(attributes.id);
+          editor.commands.toggleCheck(id);
         }
         const check = h('button', { class: 'check-list-check', onmousedown: toggle, ontouchstart: toggle, });
         if (children.length === 1 && (children[0] as VNode).type === 'br') children.push(check);
@@ -173,7 +173,7 @@ export const blockquote = line({
   renderMultiple: quotes => {
     const type = quotes[0][0].blockquote;
     const props = typeof type === 'string' ? { className: `quote-${type}`} : null;
-    const children = quotes.map(([attributes, children]) => h('p', { key: attributes.id }, children));
+    const children = quotes.map(([ attributes, children, id ]) => h('p', { key: id }, children));
     return h('blockquote', props, children);
   }
 });
@@ -185,11 +185,11 @@ export const codeblock = line({
   commands: editor => () => editor.toggleLineFormat({ ['code-block']: true }),
   renderMultiple: lines => {
     const children: VChild[] = [];
-    lines.forEach(([ attributes, inlineChildren ]) => {
+    lines.forEach(([ attributes, inlineChildren, id ]) => {
       if (inlineChildren.length && ((inlineChildren[inlineChildren.length - 1] as VNode).type === 'br')) {
         inlineChildren.pop();
       }
-      children.push(h('code', { key: attributes.id }, inlineChildren));
+      children.push(h('code', { key: id }, inlineChildren));
       children.push('\n');
     });
     return h('pre', { spellcheck: false }, children);

--- a/src/typesetting/typeset.ts
+++ b/src/typesetting/typeset.ts
@@ -42,7 +42,7 @@ export function embed(type: EmbedType) {
 }
 
 export type FromDom = (node: Node) => any;
-export type LineData = [attributes: AttributeMap, children: VChild[] ];
+export type LineData = [attributes: AttributeMap, children: VChild[], id:string];
 export type Renderer = (attributes: AttributeMap, children: VChild[], editor: Editor, forHTML?: boolean) => VNode;
 export type MultiLineRenderer = (lines: LineData[], editor: Editor, forHTML?: boolean) => VNode;
 export type ShouldCombine = (prev: AttributeMap, next: AttributeMap) => boolean;


### PR DESCRIPTION
Instead of putting line `id` on attributes and relying on `Delta.compose` to merge compose, this updates `TextDocument` to do the work of merging changes in line-by-line. It ought to be more efficient and allow the ID to remain with the line.

Thoughts @taylorhadden?