### PR TITLE
Differentiates undo actions from user actions

### DIFF
--- a/src/Source.ts
+++ b/src/Source.ts
@@ -3,4 +3,5 @@
 export enum Source {
   api = 'api',
   user = 'user',
+  undo = 'undo'
 }

--- a/src/modules/history.ts
+++ b/src/modules/history.ts
@@ -103,7 +103,7 @@ export function initHistory(initOptions: Partial<Options> = {}) {
       if (typeof entry[source] === 'function') {
         entry[source]();
       } else {
-        editor.update(entry[source]);
+        editor.update(entry[source], Source.undo);
       }
       ignoreChange = false;
     }


### PR DESCRIPTION
I added a new 'undo' source and use that when calling the undo/redo actions.

I have code that runs as the user types. It applies formatting and queues up auto-complete and auto-update behavior. Flagging undo as separate from normal user input lets me skip those pieces of functionality, preventing loops where an auto-complete behavior triggered by a text change is undone and then re-triggered, causing it to happen again.

I added a new `Source` instead of using `Source.api`, as I assumed 'api' was being used for network sync activity.