### PR TITLE
Adds options to copy, paste, and html parsing.

### DIFF
--- a/src/modules/copy.ts
+++ b/src/modules/copy.ts
@@ -3,9 +3,17 @@ import { docToHTML, inlineToHTML } from '../rendering/html';
 import TextDocument from '../doc/TextDocument';
 import { normalizeRange } from '../doc/EditorRange';
 
+const defaultOptions: CopyOptions = {
+  copyPlainText: true,
+  copyHTML: true
+}
 
+export interface CopyOptions {
+  copyPlainText?: boolean;
+  copyHTML?: boolean;
+}
 
-export function copy(editor: Editor) {
+export function copy(editor: Editor, options: CopyOptions = defaultOptions) {
 
   function onCopy(event: ClipboardEvent) {
     if (!editor.enabled || !editor.doc.selection) return;
@@ -21,15 +29,19 @@ export function copy(editor: Editor) {
     const text = slice
       .map(op => typeof op.insert === 'string' ? op.insert : ' ')
       .join('');
-    let html: string;
-    if (text.includes('\n')) {
-      slice.push({ insert: '\n', attributes: doc.getLineFormat(range[1]) });
-      html = docToHTML(editor, new TextDocument(slice));
-    } else {
-      html = inlineToHTML(editor, slice);
+    if (options.copyHTML) {
+      let html: string;
+      if (text.includes('\n')) {
+        slice.push({ insert: '\n', attributes: doc.getLineFormat(range[1]) });
+        html = docToHTML(editor, new TextDocument(slice));
+      } else {
+        html = inlineToHTML(editor, slice);
+      }
+      dataTransfer.setData('text/html', html);
     }
-    dataTransfer.setData('text/plain', text);
-    dataTransfer.setData('text/html', html);
+    if (options.copyPlainText) {
+      dataTransfer.setData('text/plain', text);
+    }
   }
 
   function onCut(event: ClipboardEvent) {

--- a/src/modules/input.ts
+++ b/src/modules/input.ts
@@ -89,12 +89,12 @@ export function input(editor: Editor) {
       const [ startNode, endNode ] = range;
       const start = getLineNodeStart(editor.root, startNode);
       const end = getLineNodeEnd(editor.root, endNode);
-      const delta = deltaFromDom(editor, { startNode, endNode: endNode.nextElementSibling || undefined });
+      const delta = deltaFromDom(editor, { startNode, endNode: endNode.nextElementSibling || undefined, collapseWhitespace: false });
       let change = doc.toDelta().slice(start, end).diff(delta);
       if (change.ops.length && start) change = new Delta().retain(start).concat(change);
       return change;
     } else {
-      const delta = deltaFromDom(editor);
+      const delta = deltaFromDom(editor, { collapseWhitespace: false });
       return doc.toDelta().diff(delta);
     }
   }

--- a/src/modules/paste.ts
+++ b/src/modules/paste.ts
@@ -27,8 +27,11 @@ export class PasteEvent extends Event {
   }
 }
 
+export interface PasteOptions {
+  htmlParser?: (editor: Editor, html: string) => Delta;
+}
 
-export function paste(editor: Editor) {
+export function paste(editor: Editor, options?: PasteOptions) {
 
   function onPaste(event: ClipboardEvent) {
     if (!editor.enabled || !editor.doc.selection) return;
@@ -45,6 +48,8 @@ export function paste(editor: Editor) {
     if (!html) {
       if (!text) return;
       delta = new Delta().insert(text);
+    } else if (options?.htmlParser) {
+      delta = options.htmlParser(editor, html);
     } else {
       delta = deltaFromHTML(editor, html, { possiblePartial: true });
     }


### PR DESCRIPTION
This adds options to the copy and paste modules that let the user configure basic behavior such as whether to copy html or how to parse html on paste.

This additionally adds configuration options whether to collapse whitespace when parsing html. This defaults to true to maintain the current behavior. However, the input module has been modified to _not_ collapse whitespace. This could be replaced with a configuration option if desired.