### PR TITLE
Fix deleting a line with formatting on it

### DIFF
--- a/src/doc/TextDocument.ts
+++ b/src/doc/TextDocument.ts
@@ -257,7 +257,15 @@ export default class TextDocument {
             lines.push(...thisIter.restLines());
             break;
           }
-        } // else ... otherOp should be a delete so we won't add the next thisOp insert
+        } else if (typeof otherOp.delete === 'number') {
+          if (thisOp.insert === '\n') {
+            // Be sure a deleted line is not kept
+            const content = line.content;
+            line = Line.createFrom(thisIter.peekLine());
+            line.content = content;
+          }
+          // else ... otherOp should be a delete so we won't add the next thisOp insert
+        }
       }
     }
 


### PR DESCRIPTION
When deleting an image line, the following line contents are added inside the image. This is because `TextDocument.apply()` doesn't skip the newline deletion correctly.

Fixes #92