### PR TITLE
Fix #78 inverted lines

### DIFF
--- a/src/doc/TextChange.ts
+++ b/src/doc/TextChange.ts
@@ -95,9 +95,12 @@ export default class TextChange {
       if (!format) format = this.getFormatAt(at);
       if (insert.includes('\n')) {
         const lines = insert.split('\n');
-        lines.forEach((line, i) => {
-          if (i) this.compose(at, delta => delta.insert('\n', i === 1 ? lineFormat : {}));
-          if (line.length) this.compose(at, delta => delta.insert(line, format))
+        this.compose(at, delta => {
+          lines.forEach((line, i) => {
+            if (i) delta.insert('\n', i === 1 ? lineFormat : {});
+            if (line.length) delta.insert(line, format);
+          });
+          return delta;
         });
         if (lineFormat) {
           this.formatLine(at, { ...lineFormat });


### PR DESCRIPTION
I'd like this to be fixed better so subsequent calls to `compose` with the same `at` will add changes after the previous ones, but this works by putting all the changes inside one compose.