### PR TITLE
Copy & Paste respect event.defaultPrevented

### DIFF
--- a/src/modules/copy.ts
+++ b/src/modules/copy.ts
@@ -42,7 +42,7 @@ export function copy(editor: Editor, options: CopyOptions = defaultOptions) {
   }
 
   function onCopy(event: ClipboardEvent) {
-    if (!editor.enabled || !editor.doc.selection) return;
+    if (!editor.enabled || !editor.doc.selection || event.defaultPrevented) return;
     event.preventDefault();
     const dataTransfer = event.clipboardData;
     if (!dataTransfer) return;

--- a/src/modules/paste.ts
+++ b/src/modules/paste.ts
@@ -113,7 +113,7 @@ export function paste(editor: Editor, options?: PasteOptions) {
   }
 
   function onPaste(event: ClipboardEvent) {
-    if (!editor.enabled || !editor.doc.selection) return;
+    if (!editor.enabled || !editor.doc.selection || event.defaultPrevented) return;
     event.preventDefault();
     const dataTransfer = event.clipboardData;
     const { doc } = editor;


### PR DESCRIPTION
This updates the Copy and Paste modules so that they do nothing if the event has already been claimed with `event.preventDefault()`.