### PR TITLE
Fix an issue that broke compound emoji characters.

### DIFF
--- a/src/rendering/html.ts
+++ b/src/rendering/html.ts
@@ -8,7 +8,7 @@ import Editor from '../Editor';
 
 // A list of bad characters that we don't want coming in from pasted content (e.g. "\f" aka line feed)
 export const BLOCK_ELEMENTS = 'address, article, aside, blockquote, editor, dd, div, dl, dt, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hr, li, main, nav, noscript, ol, output, p, pre, section, table, tfoot, ul, video';
-const BAD_CHARS = /[\0-\x09\x0B\x1F\x7F-\x9F\xAD\u0600-\u0605\u061C\u06DD\u070F\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\uE000-\uF8FF]/g;
+const BAD_CHARS = /[\0-\x09\x0B\x1F\x7F-\x9F\xAD\u0600-\u0605\u061C\u06DD\u070F\u180E\u200B-\u200C\u200E-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB\uE000-\uF8FF]/g;
 const SKIP_ELEMENTS = { STYLE: true, SCRIPT: true, LINK: true, META: true, TITLE: true, };
 const VOID_ELEMENTS = {
   area: true, base: true, br: true, col: true, embed: true, hr: true, img: true, input: true,


### PR DESCRIPTION
Unblocks `\u200D` the zero-width-joiner character. This allows combined emoji (e.g. 👨‍👩‍👧‍👦, 🤷‍♂️) to work correctly.

---

As a side note, I am curious as to how the `BAD_CHARS` list was determined. There is stuff in there, especially with regards to RTL languages, that seem like they should be included (though I am no expert).